### PR TITLE
Support patch releases

### DIFF
--- a/docker/centos-7/create_package_rpm.sh
+++ b/docker/centos-7/create_package_rpm.sh
@@ -19,7 +19,7 @@ ARCH=$(uname -m)
 VERSION_GIT=$(git describe --abbrev=6 --always --tags | cut -c 2-)
 PKG_VERSION=""
 case ${VERSION_GIT} in
-    *-alpha*|*-beta*|*-rc*)
+    *-alpha*|*-beta*|*-rc*|*-patch*)
         VERSION=$(cut -d'-' -f 1 <<< ${VERSION_GIT})
         RELEASE=$(cut -d'-' -f 2 <<< ${VERSION_GIT})
         RELEASE2=$(cut -d'-' -f 3 <<< ${VERSION_GIT})

--- a/docker/centos-7/pack.sh
+++ b/docker/centos-7/pack.sh
@@ -29,7 +29,7 @@ pushd ~/go/src/github.com/go-graphite/"${1}/"
 make clean
 REPOS="autobuilds"
 
-git describe --abbrev=6 --dirty --always --tags | grep -q '^v[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?$'
+git describe --abbrev=6 --dirty --always --tags | grep -q '^v[0-9]\+\.[0-9]\+\(\.[0-9]\+\(\-patch[0-9]\+)\?\)\?$'
 if [[ $? -eq 0 ]]; then
         REPOS="stable autobuilds"
 fi


### PR DESCRIPTION
The latest 0.17.0-patch2 didn't get uploaded to package_cloud stable, so I did some investigation for CentOS and found a few places that might go wrong.

Similar fixes might be done for other OS-es as well. Let me know if this fix is correct for CentOS and I will apply the same to others if needed.